### PR TITLE
Remove renovate.json (converging on Dependabot)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,0 @@
-{
-  "constraints": {
-  },
-  "extends": [
-    "config:base",
-    "docker:enableMajor"
-  ],
-  "ignorePaths": []
-}


### PR DESCRIPTION
Converging the org on Dependabot as the single dependency updater. This repo already has a `.github/dependabot.yml`; removing the now-redundant `renovate.json` so we stop getting two PRs for every bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)