### PR TITLE
Reduce nuisance workflow runs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,8 @@
 name: docker-test
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 jobs:
   docker-cuda-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: docker-release
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
 jobs:
   docker-cuda:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- **docker-release**: trigger only on push to main and \`v*\` tags. Previously fired on every push and \`pull_request\`, so every Dependabot PR attempted a release run that failed because the \`release\` environment blocks secrets on PRs from forks.
- **docker-test**: keep PR coverage but only trigger on main for pushes, so PR commits don't fire both \`push\` and \`pull_request\` runs.

## Test plan

- [ ] On a follow-up PR, no \`docker-release\` runs are created.
- [ ] Only one \`docker-test\` run is created per PR commit (not two).