### PR TITLE
ci: drop xpu image from test + release (too big for CI)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,23 +19,10 @@ jobs:
         tags: anarkiwi/preframr
         cache-from: type=gha
         cache-to: type=gha,mode=max
-  docker-xpu-test:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v7
-      with:
-        context: .
-        file: Dockerfile.predict
-        push: false
-        tags: anarkiwi/preframr-xpu
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
-        build-args: |
-            BASE=anarkiwi/pytorch-xpu:v2.12.0
+  # docker-xpu-test removed: the xpu image (intel pytorch-xpu base) is too
+  # large to build on the GitHub-hosted runners (disk/time). Build + test it
+  # locally instead:
+  #   docker build -f Dockerfile.predict --build-arg BASE=anarkiwi/pytorch-xpu:v2.12.0 . -t anarkiwi/preframr-xpu
   docker-jetson-test:
     runs-on: ubuntu-24.04-arm
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,36 +63,10 @@ jobs:
           anarkiwi/preframr-predict:${{ steps.ver.outputs.v }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
-  docker-xpu:
-    runs-on: ubuntu-latest
-    environment:
-      name: "release"
-    if: github.repository == 'anarkiwi/preframr'
-    steps:
-    - uses: actions/checkout@v6
-    - name: Read version
-      id: ver
-      run: echo "v=$(cat VERSION)" >> "$GITHUB_OUTPUT"
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
-    - name: Login to Docker Hub
-      uses: docker/login-action@v4
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_TOKEN }}
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v7
-      with:
-        context: .
-        file: Dockerfile.predict
-        push: true
-        tags: |
-          anarkiwi/preframr-xpu:latest
-          anarkiwi/preframr-xpu:${{ steps.ver.outputs.v }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
-        build-args: |
-            BASE=anarkiwi/pytorch-xpu:v2.12.0
+  # docker-xpu removed: the xpu image (intel pytorch-xpu base) is too large to
+  # build on the GitHub-hosted runners (disk/time). Build + publish it locally:
+  #   docker build -f Dockerfile.predict --build-arg BASE=anarkiwi/pytorch-xpu:v2.12.0 . -t anarkiwi/preframr-xpu:$(cat VERSION)
+  #   docker push anarkiwi/preframr-xpu:$(cat VERSION)
   docker-jetson:
     runs-on: ubuntu-24.04-arm
     environment:


### PR DESCRIPTION
The intel `pytorch-xpu`-based image exceeds the GitHub-hosted runners' disk/time budget. Remove it from CI:

- **`docker.yml`** — drop `docker-xpu-test`.
- **`release.yml`** — drop `docker-xpu`.

Each removal leaves an inline note explaining why + the local build/publish command. cuda / predict / jetson images are unaffected. The xpu image is still produced by `build.sh` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)