### PR TITLE
feat(predict): --predict-dump flag — emit prediction-window register …

### DIFF
--- a/preframr/args.py
+++ b/preframr/args.py
@@ -41,6 +41,14 @@ def add_args(parser):
         ),
     )
     parser.add_argument("--csv", type=str, default=None)
+    parser.add_argument(
+        "--predict-dump",
+        type=str,
+        default=None,
+        help="Write the prediction window of the audio-ready df as parquet "
+        "(register-level rows, description=1 only). For automated melody-quality "
+        "scoring downstream of predict.",
+    )
     parser.add_argument("--dataset-csv", type=str, default=None)
     parser.add_argument("--tokenizer", type=str, default="unigram")
     parser.add_argument("--token-csv", type=str, default="/scratch/preframr/token.csv")

--- a/preframr/inference/predict.py
+++ b/preframr/inference/predict.py
@@ -345,6 +345,12 @@ def generate_sequence(args, logger, dataset, predictor, p):
         reg_start=reg_start,
         descriptions=["prompt", "predictions"],
     )
+    if getattr(args, "predict_dump", None):
+        dump_path = add_ext(args.predict_dump, p)
+        pred_only = df[df["description"] == 1].reset_index(drop=True)
+        pred_only.attrs["irq"] = int(irq) if irq is not None else 0
+        pred_only.to_parquet(dump_path)
+        logger.info("wrote prediction dump (%u rows) to %s", len(pred_only), dump_path)
     if getattr(args, "play", False):
         try:
             logger.info("starting real-time playback...")


### PR DESCRIPTION
…dump

Adds the --predict-dump <path> flag that, after the WAV is rendered, writes the audio-ready df sliced to description==1 (prediction-only rows) as parquet. Downstream tooling reads this for automated melody quality scoring (see preframr-xpt audit.melody_score_generation). Five lines in predict.generate_sequence + the arg definition; no behavior change when the flag is unset.