### PR TITLE
deps: floor preframr-tokens>=0.36.0 + bridge stamp_pass

### DIFF
--- a/preframr/args.py
+++ b/preframr/args.py
@@ -422,6 +422,7 @@ _PIPELINE_NAME_TO_FLAG = {
     "loop": ("loop_pass", True),
     "coarsen": ("coarsen_pass", True),
     "fuzzy_loop": ("fuzzy_loop_pass", True),
+    "stamp": ("stamp_pass", True),
 }
 
 _LEGATO_CLUSTERS = tuple(

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ torchtune==0.6.1
 torchao==0.17.0
 zstandard==0.25.0
 preframr-audio>=0.5.3
-preframr-tokens>=0.35.0
+preframr-tokens>=0.36.0


### PR DESCRIPTION
## What
preframr-tokens **0.36.0** is released ([anarkiwi/preframr-tokens#36](https://github.com/anarkiwi/preframr-tokens/pull/36)): speculative claim/arbiter framework + the gated percussion **STAMP codebook** (flag `stamp_pass`, default OFF; drains ~93% of skeleton RESID notes / 85% frame-mass, byte-exact).

- Floor `preframr-tokens>=0.36.0` (`requirements.txt`).
- Mirror the new flag in the args pipeline-name bridge: `"stamp" -> stamp_pass` (`preframr/args.py`).

## Validation
`tests/test_args_pipeline_bridge.py` green against tokens 0.36.0 (`stamp_pass` is a registered macro flag; bridge ⊆ registered holds). `stamp_pass` is default-OFF, so default behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)