### PR TITLE
deps(tokens 0.37.0): bridge sweep_pass/held_arp/patch_pass; floor >=0.37.0

### DIFF
--- a/preframr/args.py
+++ b/preframr/args.py
@@ -423,6 +423,9 @@ _PIPELINE_NAME_TO_FLAG = {
     "coarsen": ("coarsen_pass", True),
     "fuzzy_loop": ("fuzzy_loop_pass", True),
     "stamp": ("stamp_pass", True),
+    "sweep": ("sweep_pass", True),
+    "held_arp": ("held_arp", True),
+    "patch": ("patch_pass", True),
 }
 
 _LEGATO_CLUSTERS = tuple(

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ torchtune==0.6.1
 torchao==0.17.0
 zstandard==0.25.0
 preframr-audio>=0.5.3
-preframr-tokens>=0.36.0
+preframr-tokens>=0.37.0


### PR DESCRIPTION
Cross-repo follow-up to **preframr-tokens v0.37.0** (PyPI), which added four RESID→0 mechanisms (all gated default-OFF): PATCH preamble, REL stamps, SWEEP, held-ARP.

- Mirror the new gate flags in `_PIPELINE_NAME_TO_FLAG` so a pipeline_spec can enable them by name:
  - `sweep` → `sweep_pass` (freq-domain SWEEP / skydive)
  - `held_arp` → `held_arp` (held-step wavetable ARP)
  - `patch` → `patch_pass` (melodic ADSR patch preamble)
  - (`stamp` → `stamp_pass` already bridged in #150)
- Floor `preframr-tokens>=0.37.0`.

No default behavior change (all tokens flags default-OFF; bridge only routes explicit pipeline-spec names).

🤖 Generated with [Claude Code](https://claude.com/claude-code)