### PR TITLE
fix(inference): prime event grammar state for constrained audition generation

### DIFF
--- a/preframr/inference/event_render.py
+++ b/preframr/inference/event_render.py
@@ -17,6 +17,7 @@ import pandas as pd
 from preframr_audio.audio_driver import render_to_wav
 from preframr_audio.sidwav import sidq
 from preframr_tokens import prepare_df_for_audio, read_initial_irq
+from preframr_tokens.events.constrained import EventStreamState
 from preframr_tokens.events.generate import tokens_to_writes, writes_to_dump_df
 from preframr_tokens.reglogparser import RegLogParser
 from preframr_tokens.stfconstants import DUMP_SUFFIX
@@ -24,6 +25,40 @@ from preframr_tokens.tokenizer_config import named_config
 
 _INTRA_FRAME_GAP = 8
 PAL_FRAME_CYCLES = 19656
+
+
+class EventConstraint:
+    """Event-grammar logit mask for constrained generation, PRIMED with the prompt so the mask is
+    correct at the prompt/generation boundary. The old ``StreamState`` mask keys on FRAME_REG, absent
+    from the event alphabet, so it is a no-op here and the model drifts off-grammar. Atom space ``a``
+    maps to model n-space id ``a + 1`` (id 0 = PAD)."""
+
+    def __init__(self, prompt_ids, n_vocab):
+        self.state = EventStreamState()
+        for tok in prompt_ids:
+            atom = int(tok) - 1
+            if atom >= 0:
+                self.state.push(atom)
+        self.n_vocab = int(n_vocab)
+
+    def allowed_nspace(self) -> np.ndarray:
+        """Boolean over model n-space ids: id a+1 allowed iff atom a is grammar-valid next; PAD never."""
+        vm = self.state.valid_mask()
+        nmask = np.zeros(self.n_vocab, dtype=bool)
+        k = min(len(vm), self.n_vocab - 1)
+        nmask[1 : 1 + k] = vm[:k]
+        return nmask
+
+    def mask_logits(self, logits):
+        import torch  # pylint: disable=import-outside-toplevel
+
+        allow = torch.as_tensor(self.allowed_nspace(), device=logits.device)
+        return logits.masked_fill(~allow, float("-inf"))
+
+    def update(self, tok) -> None:
+        atom = int(tok) - 1
+        if atom >= 0:
+            self.state.push(atom)
 
 
 def writes_to_timed_dump_df(writes, frame_cycles, chipno: int = 0) -> pd.DataFrame:
@@ -105,22 +140,13 @@ def run_render(args, logger):
         Predictor,
         load_model,
     )
-    from preframr_tokens import (  # pylint: disable=import-outside-toplevel
-        precompute_subtoken_arrays,
-        precompute_vocab_arrays,
-    )
 
     dataset, model, device, _ = load_model(args, logger)
     model = model.to(device)
-    if getattr(args, "tkvocab", 0) and dataset.tokenizer.tkmodel is not None:
-        vocab_arrays = precompute_subtoken_arrays(
-            dataset.tokenizer.tokens, dataset.tokenizer
-        )
-    else:
-        vocab_arrays = precompute_vocab_arrays(dataset.tokenizer.tokens)
     predictor = Predictor(
-        args, dataset, model, device, vocab_arrays=vocab_arrays, logger=logger
+        args, dataset, model, device, vocab_arrays=None, logger=logger
     )
+    n_vocab = model.model.tok_embeddings.num_embeddings
     tokenizer = dataset.tokenizer
     prompts = load_prompts(
         args.blocks_glob, args.n_prompts, args.prompt_seq_len, args.gen_tokens, logger
@@ -140,6 +166,7 @@ def run_render(args, logger):
                 temperature=temperature,
                 top_k=top_k,
                 irq=args.frame_cycles,
+                event_constraint=EventConstraint(prompt_ids, n_vocab),
             )
             .cpu()
             .numpy()

--- a/preframr/inference/predict.py
+++ b/preframr/inference/predict.py
@@ -66,7 +66,12 @@ class Predictor:
         temperature=1.0,
         top_k=None,
         irq=None,
+        event_constraint=None,
     ):
+        if event_constraint is not None:
+            return self._predict_constrained(
+                prompt, n, temperature, top_k, irq, state=event_constraint
+            )
         if self.vocab_arrays is None:
             output, _logits = generate(
                 self.model.model,
@@ -94,6 +99,7 @@ class Predictor:
         temperature,
         top_k,
         irq,
+        state=None,
     ):
         model = self.model.model
         prompt = prompt.clone().to(self.device)
@@ -123,7 +129,9 @@ class Predictor:
         input_pos = torch.arange(0, total_len, device=self.device).unsqueeze(0)
 
         prompt_ids = prompt.squeeze(0).tolist()
-        if self.vocab_arrays.get("subtoken_mode"):
+        if state is not None:
+            pass
+        elif self.vocab_arrays.get("subtoken_mode"):
             seed = StreamState(
                 self.vocab_arrays,
                 init_frame_count=0,

--- a/tests/predict/test_event_render.py
+++ b/tests/predict/test_event_render.py
@@ -6,14 +6,18 @@ import wave
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from preframr_tokens.events import oracle, stream
+from preframr_tokens.events.constrained import EventStreamState
 from preframr.inference.event_render import (
+    EventConstraint,
     writes_to_timed_dump_df,
     render_writes_to_wav,
 )
 
 PAL_FRAME_CYCLES = 19656
+N_VOCAB = stream.VOCAB_SIZE + 1
 
 
 def _synth_df(n_frames=12, seed=3):
@@ -39,6 +43,60 @@ def _synth_df(n_frames=12, seed=3):
             "val": np.array([w[2] for w in writes], dtype=np.int64),
         }
     )
+
+
+def _event_nspace(df):
+    """A synthetic tune's event atoms in model n-space (atom + 1; the model's vocab)."""
+    atoms = stream.encode(oracle.ordered_writes(df))
+    return [a + 1 for a in atoms]
+
+
+def test_primed_constraint_admits_the_true_continuation():
+    """The core audition fix: an EventConstraint PRIMED with a prompt prefix admits the real
+    continuation at every step (its grammar mask is correct at the prompt/generation boundary), so a
+    well-trained model is never masked away from a valid stream."""
+    ids = _event_nspace(_synth_df(n_frames=24))
+    split = len(ids) // 3
+    prompt, cont = ids[:split], ids[split:]
+    ec = EventConstraint(prompt, N_VOCAB)
+    for j, tok in enumerate(cont):
+        allowed = ec.allowed_nspace()
+        assert allowed[tok], f"primed mask rejected the true atom at step {j}"
+        assert (
+            0 < int(allowed.sum()) < N_VOCAB
+        ), "mask must be a non-trivial restriction"
+        ec.update(tok)
+
+
+def test_unprimed_state_rejects_a_mid_frame_continuation_that_priming_admits():
+    """Control: split mid-frame-group (just before an event-kind atom). A FRESH state expects the
+    leading frame-count varint and rejects it immediately; the PRIMED state knows it is mid-frame and
+    admits it. This is exactly why unprimed constrained generation drifted off-grammar.
+    """
+    ids = _event_nspace(_synth_df(n_frames=24))
+    kinds = set(range(stream.NI_STEP, stream.G_RAMP + 1))
+    split = next(i for i, t in enumerate(ids) if (t - 1) in kinds and i > 0)
+    prompt, nxt = ids[:split], ids[split]
+    fresh_mask = EventStreamState().valid_mask()
+    assert not fresh_mask[nxt - 1], "a fresh state must reject a mid-frame event atom"
+    assert EventConstraint(prompt, N_VOCAB).allowed_nspace()[
+        nxt
+    ], "the primed state must admit it"
+
+
+def test_mask_logits_blocks_invalid_and_keeps_valid():
+    """mask_logits sets every grammar-invalid id to -inf and leaves valid ones finite (PAD always -inf)."""
+    torch = pytest.importorskip("torch")
+    if not hasattr(torch, "zeros"):
+        pytest.skip("torch unavailable (namespace stub)")
+    ids = _event_nspace(_synth_df(n_frames=24))
+    ec = EventConstraint(ids[: len(ids) // 3], N_VOCAB)
+    logits = torch.zeros(1, N_VOCAB)
+    masked = ec.mask_logits(logits)[0].numpy()
+    allowed = ec.allowed_nspace()
+    assert np.isneginf(masked[~allowed]).all(), "invalid ids must be -inf"
+    assert np.isfinite(masked[allowed]).all(), "valid ids must stay finite"
+    assert np.isneginf(masked[0]), "PAD (id 0) is never valid"
 
 
 def test_timed_dump_has_absolute_frame_paced_clock():


### PR DESCRIPTION
Completes the audition CLI from #163: a ckpt's **generation** now decodes +
renders to WAV.

## Root cause
The audition generated event streams that wouldn't decode — `ValueError:
expected varint digit at 128` (the prompt/generation boundary). The
constrained-decode path masks logits with `StreamState`, which keys on
`FRAME_REG` (absent from the event alphabet), so the mask is a no-op for event
models **and** starts fresh at the boundary instead of continuing the prompt's
grammar. The model is steered to tokens invalid as a continuation of the prompt.

Decisive evidence (4 real captured generations, CPU, no model): a state
**primed** with the prompt admits **512/512** of the true continuation, while a
**fresh** state desyncs within **2–3 atoms**.

## Fix
Wire the event-native `EventStreamState` into generation via a new
`EventConstraint`, **primed** by pushing the prompt atoms before the first
sampled token, so the boundary mask is correct. `predict()` takes an optional
`event_constraint`; when present, `_predict_constrained` uses it and bypasses
the old `vocab_arrays`/`StreamState` build. Atom space `a` ↔ model n-space id
`a+1` (id 0 = PAD).

## Verification
- **End-to-end** (v2 baseline ckpt, tokens 0.51.0, CPU): a prompt now generates
  a stream that decodes with `trim=6` (~**0.98** of the generation) and renders
  to a coherent **0.62s WAV** (rms 4226, 297 zero-crossings) — previously *no
  WAV was produced*.
- **CPU tests** (`tests/predict/test_event_render.py`): priming-admits-the-true-
  continuation, the fresh-state desync control, and the logit mask. Existing
  render tests still green.

## Notes
- Needs `preframr-tokens>=0.51.0` (has `events.constrained`), already pinned in
  `requirements.txt`. A locally-stale `:latest` image (tokens 0.50.0) lacks it;
  a proper build / bind-mounting 0.51.0 tokens runs the audition.
- The decode side (`decode_tolerant`, keyframe-stripping via `ids_to_writes`)
  needed no change once generations are valid — it just trims the fixed-length
  generation's truncated tail.
- The `preframr-xpt` work order can be removed there once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)