### PR TITLE
fix(audition): snap event prompts to whole-frame boundaries

### DIFF
--- a/preframr/inference/event_gate.py
+++ b/preframr/inference/event_gate.py
@@ -35,6 +35,22 @@ def add_gate_args(parser):
     return parser
 
 
+def _frame_cut(nonzero, prompt_seq_len):
+    """Largest whole-frame boundary at or before ``prompt_seq_len``. A prefix
+    parses iff it is a whole number of frames, so the longest prefix (capped at
+    ``prompt_seq_len``) that ``unit_starts`` accepts is the snap point. The block
+    is a seq_len window that may itself end mid-frame, so never parse the whole
+    row -- only the bounded prefix."""
+    hi = min(len(nonzero), prompt_seq_len)
+    while hi > 0:
+        try:
+            unit_starts(nonzero[:hi].tolist())
+            return hi
+        except ValueError:
+            hi -= 1
+    return prompt_seq_len
+
+
 def load_prompts(blocks_glob, n_prompts, prompt_seq_len, gen_tokens, logger):
     """First qualifying block per file (deduped songs), up to ``n_prompts``. The
     prompt is cut at the last grammar-unit (whole-frame) boundary at or before
@@ -47,10 +63,7 @@ def load_prompts(blocks_glob, n_prompts, prompt_seq_len, gen_tokens, logger):
             nonzero = row[row > 0]
             if len(nonzero) < prompt_seq_len + 1:
                 continue
-            starts = [
-                s for s in unit_starts(nonzero.tolist()) if 0 < s <= prompt_seq_len
-            ]
-            cut = starts[-1] if starts else prompt_seq_len
+            cut = _frame_cut(nonzero, prompt_seq_len)
             prompt = nonzero[:cut].astype(np.int64)
             truth = nonzero[cut : cut + gen_tokens].astype(np.int64)
             if len(truth):

--- a/preframr/inference/event_gate.py
+++ b/preframr/inference/event_gate.py
@@ -19,6 +19,7 @@ import torch
 from preframr.args import add_args
 from preframr.inference.predict import Predictor, load_model
 from preframr.utils import get_logger
+from preframr_tokens.events.dataset import unit_starts
 from preframr_tokens.events.generate import tokens_to_writes
 
 
@@ -35,7 +36,10 @@ def add_gate_args(parser):
 
 
 def load_prompts(blocks_glob, n_prompts, prompt_seq_len, gen_tokens, logger):
-    """First qualifying block per file (deduped songs), up to ``n_prompts``."""
+    """First qualifying block per file (deduped songs), up to ``n_prompts``. The
+    prompt is cut at the last grammar-unit (whole-frame) boundary at or before
+    ``prompt_seq_len``; a fixed atom cut lands mid-frame, so the prompt is not a
+    self-contained decodable stream and the audition renders silent."""
     prompts = []
     for path in sorted(glob.glob(blocks_glob, recursive=True)):
         arr = np.load(path)
@@ -43,10 +47,12 @@ def load_prompts(blocks_glob, n_prompts, prompt_seq_len, gen_tokens, logger):
             nonzero = row[row > 0]
             if len(nonzero) < prompt_seq_len + 1:
                 continue
-            prompt = nonzero[:prompt_seq_len].astype(np.int64)
-            truth = nonzero[prompt_seq_len : prompt_seq_len + gen_tokens].astype(
-                np.int64
-            )
+            starts = [
+                s for s in unit_starts(nonzero.tolist()) if 0 < s <= prompt_seq_len
+            ]
+            cut = starts[-1] if starts else prompt_seq_len
+            prompt = nonzero[:cut].astype(np.int64)
+            truth = nonzero[cut : cut + gen_tokens].astype(np.int64)
             if len(truth):
                 prompts.append((path, prompt, truth))
                 break


### PR DESCRIPTION
## Why

Generated auditions render **silent after an initial pop**. Root cause: `load_prompts` cut prompts at a fixed `prompt_seq_len` (128) atom count, which lands **mid-frame**. The grammar-unit boundaries near 128 are e.g. `105`/`131`, not `128`, so the prompt is not a self-contained decodable stream.

The strict event-grammar decoder needs whole frames, and `decode_tolerant` floors trimming at `min_keep=len(prompt)`, so it can never recover the prompt's last whole frame. Diagnosed on the v2 audition npz:

- 3/4 prompts: **nothing** past the prompt decodes (error at the prompt boundary).
- 1/4 (sample 0): only **11 frames / 33 writes (~0.2s)** decode, then the divergent continuation goes grammatically invalid → trimmed away. That is the "pop then silence."
- The renderer/decoder are correct: ground-truth continuations decode to 514 frames of real music.

The `memorize` smoke test masked this because `gen==truth` reconstructs the original frame-aligned block exactly; the bug only bites when generation diverges from truth (real free-running).

## Fix

Snap the prompt to the last `unit_starts()` boundary at or before `prompt_seq_len`, so the prompt is frame-complete and the model's continuation begins at a clean frame start.

## Verification (CPU, v2 corpus)

| block | OLD `prompt[:128]` | NEW snapped prompt |
|---|---|---|
| 0 | FAIL (varint at boundary) | OK `prompt[:105]` decodes |
| 1 | FAIL | OK `prompt[:90]` decodes |
| 2 | FAIL | OK `prompt[:61]` decodes |

A clean free-running WAV audition still needs a GPU re-gen with this harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)