### PR TITLE
fix(audition): _frame_cut catches IndexError from unit_starts

### DIFF
--- a/preframr/inference/event_gate.py
+++ b/preframr/inference/event_gate.py
@@ -46,7 +46,7 @@ def _frame_cut(nonzero, prompt_seq_len):
         try:
             unit_starts(nonzero[:hi].tolist())
             return hi
-        except ValueError:
+        except (ValueError, IndexError):
             hi -= 1
     return prompt_seq_len
 


### PR DESCRIPTION
`unit_starts()` raises `IndexError` (not only `ValueError`) when a prompt prefix ends mid-nibble (a truncated ctrl/env value). The `_frame_cut` snap loop (added in #168) only caught `ValueError`, so the `IndexError` escaped and crashed `load_prompts` on some eval-B prompts (hit while building the Tier-4 recoverability triage). Catch both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)