### PR TITLE
feat(audition): default render CLI to off-ramp settings

### DIFF
--- a/preframr/inference/event_render.py
+++ b/preframr/inference/event_render.py
@@ -207,6 +207,7 @@ def main():
     parser = add_gate_args(add_args(argparse.ArgumentParser()))
     parser.add_argument("--wav-dir", default="/scratch/tmp/auditions")
     parser.add_argument("--frame-cycles", type=int, default=PAL_FRAME_CYCLES)
+    parser.set_defaults(repetition_penalty=1.3, no_repeat_ngram_size=4, top_k=8)
     args = parser.parse_args()
     sys.exit(run_render(args, get_logger("INFO")))
 


### PR DESCRIPTION
Defaults the audition/render CLI to the shipped free-running off-ramp (constrained decode + Tier-1 caps: rep 1.3 / no-repeat-ngram 4 / top-k 8). Produces sustained audible output instead of the drone/collapse; all flags still overridable. See xpt `design/generation/generation_offramp_shipped.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)